### PR TITLE
upper limit flax version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = [
     'scipy',
     'tqdm',
     'jax>=0.4, <0.5',
-    'flax',
+    'flax<=0.7.0',
     'jraph',
     'pyscf',
     'optax',


### PR DESCRIPTION
In Flax version 0.7.1 and later, the flax.linen.Module no longer supports the .unfreeze() method. This change results in an error in the file /pesnet/nn/pesnet.py at line 313, where fermi_params = ferminet.init(subkey, electrons, atoms).unfreeze() is causing an AttributeError: 'dict' object has no attribute 'unfreeze'. As a result, the maximum supported Flax version is restricted to 0.7.0.